### PR TITLE
Update README.md with Details for Murdoch University

### DIFF
--- a/README.md
+++ b/README.md
@@ -1113,7 +1113,7 @@ iptables -t nat -I POSTROUTING -p udp -m udp --sport 123 -j MASQUERADE --to-port
 |`ns4.murdoch.edu.au:123`|134.115.4.34|4|s2|no-leap|
 |`ntp.murdoch.edu.au:123`|134.115.4.33|4|s3|no-leap|
 |`prawn.murdoch.edu.au:123`|134.115.4.33|4|s3|no-leap|
-|`spider.murdoch.edu.au:123`|134.115.4.34|4|s3|no-leap|
+|`spider.murdoch.edu.au:123`|134.115.4.34|4|s2|no-leap|
 |`www.murdoch.edu.au:123`|||||
 
 ### MyNet

--- a/README.md
+++ b/README.md
@@ -1107,11 +1107,13 @@ iptables -t nat -I POSTROUTING -p udp -m udp --sport 123 -j MASQUERADE --to-port
 
 | endpoint | ip address | version | stratum | leap |
 | -------- | ---------- | ------- | ------- | ---- |
-|`ns1.murdoch.edu.au:123`|||||
-|`ns2.murdoch.edu.au:123`|||||
-|`ns3.murdoch.edu.au:123`|||||
-|`ns4.murdoch.edu.au:123`|||||
-|`ntp.murdoch.edu.au:123`|||||
+|`ns1.murdoch.edu.au:123`|134.115.4.33|4|s3|no-leap|
+|`ns2.murdoch.edu.au:123`|134.115.4.33|4|s3|no-leap|
+|`ns3.murdoch.edu.au:123`|134.115.4.34|4|s2|no-leap|
+|`ns4.murdoch.edu.au:123`|134.115.4.34|4|s2|no-leap|
+|`ntp.murdoch.edu.au:123`|134.115.4.33|4|s3|no-leap|
+|`prawn.murdoch.edu.au:123`|134.115.4.33|4|s3|no-leap|
+|`spider.murdoch.edu.au:123`|134.115.4.34|4|s3|no-leap|
 |`www.murdoch.edu.au:123`|||||
 
 ### MyNet


### PR DESCRIPTION
### DESCRIPTION
- Added details for NTP servers operated from Murdoch University
- Added `prawn.murdoch.edu.au:123` and `spider.murdoch.edu.au:123` for Murdoch University (Note, `ns1` to `ns4` and `ntp` servers at Murdoch University all traceroute back to the same IP addresses as `prawn` and `spider`)